### PR TITLE
Итерация 11. Хранилище в БД

### DIFF
--- a/internal/server/api/interface.go
+++ b/internal/server/api/interface.go
@@ -13,8 +13,8 @@ var (
 	ErrorUnknownMetricType = errors.New("неизвестная метрика, доступны значения counter и gauge")
 	ErrorUpdateCheckFailed = errors.New("обновление не удалось")
 	ErrorNotFoundMetric    = errors.New("метрика с указанным именем не найдена")
-	ErrorDeltaEmpty        = errors.New("поле Delta не может быть пустым, для когда id=counter")
-	ErrorValueEmpty        = errors.New("поле Value не может быть пустым, для когда id=gauge")
+	ErrorDeltaEmpty        = errors.New("поле Delta не может быть пустым, для когда mtype=counter")
+	ErrorValueEmpty        = errors.New("поле Value не может быть пустым, для когда mtype=gauge")
 
 	ErrorNoDatabase              = errors.New("база данных в текущей конфигурации не исползуется")
 	ErrorNoConntectionToDatabase = errors.New("нет связи с базой данных")

--- a/internal/server/api/json_handlers.go
+++ b/internal/server/api/json_handlers.go
@@ -61,7 +61,7 @@ func HandleJSONRequest(handler func(context.Context, ...metrica.Metrica) (out []
 				HTTPErrorWithLogging(w, http.StatusNotFound, "В хранилище не найдена метрика %v", in.ID)
 				return
 			}
-			HTTPErrorWithLogging(w, http.StatusBadRequest, "Ошибка обновления метрики %+v: %v", in, err) // todo, а как бы сделать так, чтобы %v подсвечивался
+			HTTPErrorWithLogging(w, http.StatusBadRequest, "Ошибка в работе хендлера метрике %+v: %v", in, err) // todo, а как бы сделать так, чтобы %v подсвечивался
 			return
 		}
 

--- a/internal/storage/postgre.go
+++ b/internal/storage/postgre.go
@@ -3,30 +3,53 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/rs/zerolog/log"
 	"github.com/thefrol/kysh-kysh-meow/internal/metrica"
 	"github.com/thefrol/kysh-kysh-meow/internal/server/api"
 )
 
+var (
+	ErrorInitDatabase = errors.New("невозможно инициализировать базу данных, создать таблицы counter и gauge")
+)
+
+const (
+	initQuery = "CREATE TABLE IF NOT EXISTS counters(id TEXT PRIMARY KEY, delta INTEGER);" +
+		"CREATE TABLE IF NOT EXISTS gauges(id TEXT PRIMARY KEY, value DOUBLE PRECISION);" // todo вот тут я бы уже делал ошибку обертку, соишком много тонкостей и синтакс и ещё соединения
+
+	queryGetCounter = "SELECT id, delta FROM counters WHERE id=$1;"
+	queryGetGauge   = "SELECT id, value FROM gauges WHERE id=$1;"
+
+	queryList = "SELECT 'counter',id FROM counters UNION SELECT 'gauge',id from gauges;"
+
+	queryUpdateCounter = "UPDATE counters SET delta=delta+$2 WHERE id=$1"
+	queryInsertCounter = "INSERT INTO counters VALUES ($1,$2);"
+	queryUpsertGauge   = "INSERT INTO gauges VALUES ($1,$2) ON CONFLICT (id) DO UPDATE SET value=$2;"
+)
+
 // Database это приложение сервера, которое умеет работать с базой данных, и другими хранилищами. Со всеми вещами от которого, он зависит.
 type Database struct {
-	db  *sql.DB
-	ctx context.Context
+	db *sql.DB
 }
 
 const sqldriver = "pgx"
 
 // New cоздает новый объект приложения, получая на вход параметры конфигурации
 func NewPostGresDatabase(ctx context.Context, connString string) (*Database, error) {
-
 	db, err := sql.Open(sqldriver, connString)
 	if err != nil {
 		return nil, err
 	}
+
+	// инициализуем таблицы для гаужей и каунтеров
+	_, err = db.ExecContext(ctx, initQuery)
+	if err != nil {
+		return nil, ErrorInitDatabase
+	}
 	return &Database{
-		db:  db,
-		ctx: ctx,
+		db: db,
 	}, nil
 }
 
@@ -36,27 +59,147 @@ func (d *Database) Check(ctx context.Context) error {
 }
 
 // Get implements api.Operator.
-func (*Database) Get(ctx context.Context, req ...metrica.Metrica) (resp []metrica.Metrica, err error) {
-	panic("unimplemented")
+func (d *Database) Get(ctx context.Context, req ...metrica.Metrica) (resp []metrica.Metrica, err error) {
+	resp = make([]metrica.Metrica, 0, len(req))
+
+	for _, r := range req {
+		switch r.MType {
+		case "counter":
+			result := metrica.Metrica{MType: r.MType, Delta: new(int64)}
+			rw := d.db.QueryRowContext(ctx, queryGetCounter, r.ID)
+			err := rw.Scan(&result.ID, result.Delta)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return nil, api.ErrorNotFoundMetric
+				}
+				return nil, err
+			}
+			resp = append(resp, result)
+
+		case "gauge":
+			result := metrica.Metrica{MType: r.MType, Value: new(float64)}
+			rw := d.db.QueryRowContext(ctx, queryGetGauge, r.ID)
+			err := rw.Scan(&result.ID, result.Value)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return nil, api.ErrorNotFoundMetric
+				}
+				return nil, err
+			}
+			resp = append(resp, result)
+		default:
+			return nil, api.ErrorUnknownMetricType
+		}
+	}
+
+	return resp, nil
 }
 
 // List implements api.Operator.
-func (*Database) List(ctx context.Context) (counterNames []string, gaugeNames []string, err error) {
-	panic("unimplemented")
+func (d *Database) List(ctx context.Context) (counterNames []string, gaugeNames []string, err error) {
+	metrics := make(map[string][]string, 2)
+	metrics["counter"] = make([]string, 0, 10)
+	metrics["gauge"] = make([]string, 0, 30) // todo, если бы мы знали количество возвращаемых строк, то можно было бы тут поменьше памяти выделять
+
+	rs, err := d.db.QueryContext(ctx, queryList)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var mtype, id string
+	for rs.Next() {
+		err := rs.Scan(&mtype, &id)
+		if err != nil {
+			return nil, nil, err
+		}
+		metrics[mtype] = append(metrics[mtype], id)
+	}
+
+	if err := rs.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	return metrics["counter"], metrics["gauge"], nil
 }
 
 // Update implements api.Operator.
-func (*Database) Update(ctx context.Context, req ...metrica.Metrica) (resp []metrica.Metrica, err error) {
-	panic("unimplemented")
-}
+func (d *Database) Update(ctx context.Context, req ...metrica.Metrica) (resp []metrica.Metrica, err error) {
+	tx, err := d.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
 
-func (d Database) Database() *sql.DB {
-	return d.db
-}
+	for _, r := range req {
+		switch r.MType {
+		case "counter":
+			/*
+				1. Пробуем делать UPDATE ... SET value=value+delta
+				2. Если количество обновленных полей =0, делаем INSERT INTO
+			*/
 
-func (d Database) Context() context.Context {
-	// todo не понимаю можно ли так передавать контекст по значению
-	return d.ctx
+			if r.Delta == nil {
+				return nil, api.ErrorDeltaEmpty
+			}
+
+			// todo не помню, надо ли тут проверять на всякие пустые ссылки...
+			rs, err := tx.ExecContext(ctx, queryUpdateCounter, r.ID, r.Delta)
+			if err != nil {
+				return nil, err
+			}
+			count, err := rs.RowsAffected()
+			if err != nil {
+				return nil, err
+			}
+			if count > 1 {
+				log.Warn().Msgf("При транзакции обновлено несколько строк %+v", r)
+			}
+			if count == 0 {
+				// Значит счетчик не создан, значит создадим
+				_, err := tx.ExecContext(ctx, queryInsertCounter, r.ID, r.Delta)
+				if err != nil {
+					return nil, err
+				}
+			}
+
+		case "gauge":
+			if r.Value == nil {
+				return nil, api.ErrorValueEmpty
+			}
+
+			_, err := tx.ExecContext(ctx, queryUpsertGauge, r.ID, r.Value)
+			if err != nil {
+				return nil, err
+			}
+		default:
+			return nil, api.ErrorUnknownMetricType
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, err
+	}
+
+	/// возвращаем обновленные метрики
+	return d.Get(ctx, req...)
 }
 
 var _ api.Operator = (*Database)(nil)
+
+// TODO
+//
+// Альтернативный способ получить все метрики одним запросом
+//
+// SELECT 'counter', id, delta, NULL FROM counters WHERE id IN ('test1','test2')
+//   UNION
+//   SELECT 'gauge', id, NULL, value FROM gauges WHERE id IN ('gaug2', 'gaug3')
+//
+// получим три столбца прям как в Metrica
+//
+//  ?column? |  id   | ?column? | delta
+// ----------+-------+----------+-------
+//  counter  | test1 |          |    20
+//  counter  | test2 |          |    40
+//  gauge    | gaug3 |  50.22   |
+//


### PR DESCRIPTION
# Переезжаем в `POSTGRES`

После последнего обновления хранилища переезд был максимально прост и безболезненен, нужно было просто реализовать класс `storage.Database`. 

## Архитектура

У нас две таблицы: `counters` и  `gauges` с похожими полями
+ id TEXT, delta INTEGER
+ id TEXT, delta DOUBLE PRECISION

## Счетчики

Чтобы обновить счетчик мы сначала пытаемся `UPDATE ... SET delta=delta+$1`, а если не получается, то есть нет записи в базе - просто добавляем её "INSERT INTO"

## Гаужи

Чтобы обновить пользуемся upsert конструкцией "INSERT ... ON CONFLICT UPDATE SET ...". Примем эта конструкция не работает для счетчиков

## Список
Чтобы получить список счетчиков, мы пользуемся UNION из полей id двух таблиц, и в итоге вывод такого формата

'counter','counter1'
'counter','counter2'
'gauge','gauge2`