### PR TITLE
Ограничить количество исходящих соединений

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -55,8 +55,9 @@ func FetchAndReport(config config.Agent, updateRoute string) {
 	url := Endpoint(config.Addr, updateRoute)
 
 	inCh := WithTimeouts(inMix, reportInterval)
+	sema := NewSemaphore(2)
 	for i := 0; i < workerCount; i++ {
-		worker(inCh, url)
+		worker(inCh, url, sema)
 	}
 	// надо конечно подумать над такими вещами, что если метрики не отправились? бросить их обратно в начало или в какую-то
 	// Дополнительную очередь?

--- a/internal/collector/workerpool.go
+++ b/internal/collector/workerpool.go
@@ -28,7 +28,9 @@ func worker(inCh <-chan metrica.Metrica, url string, sema Semaphore) {
 	for v := range inCh {
 		batch = append(batch, v)
 		if len(batch) >= MaxBatch {
+			sema.Acquire()
 			sendBatch(batch, url)
+			sema.Release()
 			batch = batch[:0]
 		}
 		// можно улучшить через default

--- a/internal/config/agent.go
+++ b/internal/config/agent.go
@@ -15,6 +15,7 @@ type Agent struct {
 	Addr            string `env:"ADDRESS" flag:"~a" desc:"(строка) адрес сервера в формате host:port"`
 	ReportInterval  uint   `env:"REPORT_INTERVAL" flag:"~r" desc:"(число, секунды) частота отправки данных на сервер"`
 	PollingInterval uint   `env:"POLLING_INTERVAL" flag:"~p" desc:"(число, секунды) частота отпроса метрик"`
+	RateLimit       uint   `env:"RATE_LIMIT"`
 	Key             Secret `env:"KEY" flag:"~p" desc:"(строка) секретный ключ подписи"`
 }
 
@@ -30,12 +31,18 @@ func (cfg *Agent) Parse(defaults Agent) error {
 	flag.UintVar(&cfg.ReportInterval, "r", defaults.ReportInterval, "число, частота отправки данных на сервер")
 	flag.StringVar(&cfg.Addr, "a", defaults.Addr, "строка, адрес сервера в формате host:port")
 	flag.Var(&cfg.Key, "k", "строка, секретный ключ подписи")
+	flag.UintVar(&cfg.RateLimit, "l", defaults.RateLimit, "число, максимальное количество исходящих запросов")
 
 	flag.Parse()
 
 	err := env.Parse(cfg)
 	if err != nil {
 		return err
+	}
+
+	// Валидация
+	if cfg.RateLimit == 0 {
+		return fmt.Errorf("Ошибка при конфигурировании, количество исходящих соединения не может быть меньше 1")
 	}
 
 	log.Info().Msgf("Запущено с настройками %+v", cfg)


### PR DESCRIPTION
Тут добавлен новый параметр командной строки. И при помощи семафора ограничиваем отправку.

В первом коммите я на самом деле исправляю отправку, там не очищался буфер `batch`